### PR TITLE
Remove full stop/period from you_have_been_registered string in selected textpacks

### DIFF
--- a/textpacks/bg-bg.textpack
+++ b/textpacks/bg-bg.textpack
@@ -56,7 +56,7 @@ your_login_info => Вашата потребителска информация
 your_login_is => Вашето потребителско име е
 your_new_password => Вашата нова парола е
 your_password_is => Вашата парола е
-you_have_been_registered => Вие сте регистриран като сътрудник на сайта.
+you_have_been_registered => Вие сте регистриран като сътрудник на сайта
 #@article
 advanced_options => Допълнителни опции
 article_day => Ден

--- a/textpacks/ca-es.textpack
+++ b/textpacks/ca-es.textpack
@@ -56,7 +56,7 @@ your_login_info => La teva informació d’accés
 your_login_is => El teu nom d’usuari és
 your_new_password => La teva nova contrasenya
 your_password_is => La teva contrasenya és
-you_have_been_registered => Has estat registrat com a col·laborador del lloc.
+you_have_been_registered => Has estat registrat com a col·laborador del lloc
 #@article
 advanced_options => Opcions avançades
 article_day => Dia

--- a/textpacks/cs-cz.textpack
+++ b/textpacks/cs-cz.textpack
@@ -56,7 +56,7 @@ your_login_info => Přihlašovací údaje
 your_login_is => Jméno uživatele je
 your_new_password => Nové heslo je
 your_password_is => Heslo uživatele je
-you_have_been_registered => Byl jsi přihlášen(a) jako uživatel na stránkách.
+you_have_been_registered => Byl jsi přihlášen(a) jako uživatel na stránkách
 #@article
 advanced_options => Rozšířené nastavení
 article_day => Den

--- a/textpacks/da-dk.textpack
+++ b/textpacks/da-dk.textpack
@@ -56,7 +56,7 @@ your_login_info => Dine logind info
 your_login_is => Dit brugernavn er
 your_new_password => Dit nye kodeord
 your_password_is => Dit kodeord er
-you_have_been_registered => Du er blevet registreret som bidragyder til siden.
+you_have_been_registered => Du er blevet registreret som bidragyder til siden
 #@article
 advanced_options => Avancerede indstillinger
 article_day => Dag

--- a/textpacks/de-de.textpack
+++ b/textpacks/de-de.textpack
@@ -56,7 +56,7 @@ your_login_info => Ihre Anmeldeinformationen
 your_login_is => Ihr Benutzername lautet
 your_new_password => Ihr neues Passwort
 your_password_is => Das Passwort lautet
-you_have_been_registered => Sie wurden als Mitarbeiter(in) dieser Seite registriert.
+you_have_been_registered => Sie wurden als Mitarbeiter(in) dieser Seite registriert
 #@article
 advanced_options => Erweiterte Einstellungen
 article_day => Tag

--- a/textpacks/el-gr.textpack
+++ b/textpacks/el-gr.textpack
@@ -56,7 +56,7 @@ your_login_info => Οι πληροφορίες για την πρόσβασή σ
 your_login_is => Το όνομα χρήστη σας
 your_new_password => Ο νέος σας κωδικός πρόσβασης
 your_password_is => Ο κωδικός πρόσβασής σας
-you_have_been_registered => Έχετε εγγραφεί ως χρήστης στον ιστότοπο.
+you_have_been_registered => Έχετε εγγραφεί ως χρήστης στον ιστότοπο
 #@article
 advanced_options => Προχωρημένες επιλογές
 article_day => Ημέρα

--- a/textpacks/en-gb.textpack
+++ b/textpacks/en-gb.textpack
@@ -56,7 +56,7 @@ your_login_info => Your login info
 your_login_is => Your login is
 your_new_password => Your new password
 your_password_is => Your password is
-you_have_been_registered => You have been registered as a contributor to the site.
+you_have_been_registered => You have been registered as a contributor to the site
 #@article
 advanced_options => Advanced options
 article_day => Day

--- a/textpacks/en-us.textpack
+++ b/textpacks/en-us.textpack
@@ -56,7 +56,7 @@ your_login_info => Your login info
 your_login_is => Your login is
 your_new_password => Your new password
 your_password_is => Your password is
-you_have_been_registered => You have been registered as a contributor to the site.
+you_have_been_registered => You have been registered as a contributor to the site
 #@article
 advanced_options => Advanced options
 article_day => Day

--- a/textpacks/es-es.textpack
+++ b/textpacks/es-es.textpack
@@ -56,7 +56,7 @@ your_login_info => Tu información de acceso
 your_login_is => Tu nombre de acceso es
 your_new_password => Tu nueva contraseña
 your_password_is => Tu contraseña es
-you_have_been_registered => Has sido registrado como colaborador del sitio.
+you_have_been_registered => Has sido registrado como colaborador del sitio
 #@article
 advanced_options => Opciones avanzadas
 article_day => Día

--- a/textpacks/et-ee.textpack
+++ b/textpacks/et-ee.textpack
@@ -56,7 +56,7 @@ your_login_info => Sinu login info
 your_login_is => Sinu login on
 your_new_password => Sinu uus parool on
 your_password_is => Sinu parool on
-you_have_been_registered => Sa oled registreerunud kaastöötajana.
+you_have_been_registered => Sa oled registreerunud kaastöötajana
 #@article
 advanced_options => Keerukamad seaded
 article_day => Päev

--- a/textpacks/fi-fi.textpack
+++ b/textpacks/fi-fi.textpack
@@ -56,7 +56,7 @@ your_login_info => Kirjautumistietosi
 your_login_is => Kirjautumisnimesi on
 your_new_password => Uusi salasanasi
 your_password_is => Salasanasi on
-you_have_been_registered => Sinut on rekisteröity sisällöntuottajaksi sivustoon.
+you_have_been_registered => Sinut on rekisteröity sisällöntuottajaksi sivustoon
 #@article
 advanced_options => Lisävalinnat
 article_day => Päivä

--- a/textpacks/fr-fr.textpack
+++ b/textpacks/fr-fr.textpack
@@ -56,7 +56,7 @@ your_login_info => Vos informations de connexion
 your_login_is => Votre nom de connexion (login) est
 your_new_password => Votre nouveau mot de passe
 your_password_is => Votre mot de passe est
-you_have_been_registered => Vous avez été enregistré comme contributeur du site.
+you_have_been_registered => Vous avez été enregistré comme contributeur du site
 #@article
 advanced_options => Configuration avancée
 article_day => Jour

--- a/textpacks/he-il.textpack
+++ b/textpacks/he-il.textpack
@@ -56,7 +56,7 @@ your_login_info => מידע ההתחברות שלך
 your_login_is => שם המשתמש שלך הוא
 your_new_password => הסיסמה החדשה שלך היא
 your_password_is => הסיסמה שלך היא
-you_have_been_registered => נרשמת כתורם לאתר.
+you_have_been_registered => נרשמת כתורם לאתר
 #@article
 advanced_options => אפשרויות מתקדמות
 article_day => יום

--- a/textpacks/ja-jp.textpack
+++ b/textpacks/ja-jp.textpack
@@ -56,7 +56,7 @@ your_login_info => あなたのログイン情報
 your_login_is => あなたのログインは
 your_new_password => 新しいパスワード
 your_password_is => あなたのパスワード
-you_have_been_registered => あなたは以下のサイトのユーザに登録されました。
+you_have_been_registered => あなたは以下のサイトのユーザに登録されました
 #@article
 advanced_options => 詳細設定
 article_day => 日

--- a/textpacks/ko-kr.textpack
+++ b/textpacks/ko-kr.textpack
@@ -56,7 +56,7 @@ your_login_info => 로그인 정보
 your_login_is => 로그인 id
 your_new_password => 새 비밀번호
 your_password_is => 새 비밀번호는
-you_have_been_registered => 이 사이트의 글쓴이로 등록되었습니다.
+you_have_been_registered => 이 사이트의 글쓴이로 등록되었습니다
 #@article
 advanced_options => 상세 설정
 article_day => 일

--- a/textpacks/nl-nl.textpack
+++ b/textpacks/nl-nl.textpack
@@ -56,7 +56,7 @@ your_login_info => Je login info
 your_login_is => Je loginnaam is
 your_new_password => Je nieuwe wachtwoord
 your_password_is => Je wachtwoord is
-you_have_been_registered => Je bent geregistreerd als medewerker van de site:
+you_have_been_registered => Je bent geregistreerd als medewerker van de site
 #@article
 advanced_options => Meer opties
 article_day => Dag

--- a/textpacks/pl-pl.textpack
+++ b/textpacks/pl-pl.textpack
@@ -56,7 +56,7 @@ your_login_info => Informacja o Twoim koncie
 your_login_is => Twoja nazwa użytkownika:
 your_new_password => Twoje nowe hasło:
 your_password_is => Twoje hasło:
-you_have_been_registered => Jesteś teraz zarejestrowanym współautorem strony.
+you_have_been_registered => Jesteś teraz zarejestrowanym współautorem strony
 #@article
 advanced_options => Opcje zaawansowane
 article_day => Data

--- a/textpacks/ru-ru.textpack
+++ b/textpacks/ru-ru.textpack
@@ -56,7 +56,7 @@ your_login_info => Ваша регистрационная информация
 your_login_is => Ваш логин
 your_new_password => Ваш новый пароль
 your_password_is => Ваш пароль
-you_have_been_registered => Вы были зарегистрированы как участник в разработке сайта.
+you_have_been_registered => Вы были зарегистрированы как участник в разработке сайта
 #@article
 advanced_options => Продвинутые настройки
 article_day => День


### PR DESCRIPTION
Lessens the awkwardness of this incorrectly-formatted sentence in the welcome email:

```
You have been registered as a contributor to the site. My Site Name
```

Some textpacks had a trailing . after the `you_have_been_registered` string, others didn’t - this unifies them, to the best of my knowledge. It still doesn’t have a trailing . to indicate the end of the sentence proper (after site name), but it’s a start. The string `you_have_been_registered` string is currently only used in the welcome email.
