### PR TITLE
`referrers` to `hits`

### DIFF
--- a/textpacks/en-gb.textpack
+++ b/textpacks/en-gb.textpack
@@ -531,7 +531,7 @@ manage => Manage
 #@log
 logs => Logs
 logs_deleted => Logs deleted: <strong>{list}</strong>.
-no_refers_recorded => No referrers recorded.
+no_refers_recorded => No hits recorded.
 referrer => Referrer
 visitor_logs => Visitor logs
 #@page

--- a/textpacks/en-us.textpack
+++ b/textpacks/en-us.textpack
@@ -531,7 +531,7 @@ manage => Manage
 #@log
 logs => Logs
 logs_deleted => Logs deleted: <strong>{list}</strong>.
-no_refers_recorded => No referrers recorded.
+no_refers_recorded => No hits recorded.
 referrer => Referrer
 visitor_logs => Visitor logs
 #@page


### PR DESCRIPTION
Tenuous, perhaps, but regardless of the visitor logging level (none, referrers only, all hits), no recorded entries will throw up a reference to `referrers`, which is confusing. This fixes it.
